### PR TITLE
Setup Go Releaser in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,27 +17,24 @@ jobs:
     - uses: actions/checkout@v3
     - run: go test ./internal
 
-  build-binaries:
+  goreleaser:
     runs-on: ubuntu-latest
     needs: test
     permissions:
       contents: write
-    strategy:
-      matrix:
-        goos: [linux, windows, darwin]
-        goarch: ["386", amd64, arm64]
-        exclude:
-          - goarch: "386"
-            goos: darwin
-          - goarch: arm64
-            goos: windows
     steps:
-    - uses: actions/checkout@v3
-    - uses: wangyoucao577/go-release-action@v1.31
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        project_path: "./cmd/cli"
-        binary_name: "goke"
-        extra_files: LICENSE README.md
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+          cache: true
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,6 @@ before:
   hooks:
     - go mod tidy
     - go generate ./...
-    - go test ./internal
 builds:
   - main: ./cmd/cli
     env:
@@ -19,6 +18,7 @@ brews:
     tap:
       owner: dugajean
       name: homebrew-goke
+      token: "{{ .Env.GITHUB_TOKEN }}"
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,6 @@ brews:
     tap:
       owner: dugajean
       name: homebrew-goke
-      token: "{{ .Env.GITHUB_TOKEN }}"
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,12 @@ builds:
       - linux
       - windows
       - darwin
+brews:
+  - name: goke
+    homepage: https://github.com/dugajean/homebrew-goke
+    tap:
+      owner: dugajean
+      name: homebrew-goke
 archives:
   - replacements:
       darwin: Darwin

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Goke is a build automation tool, similar to Make, but without the Makefile clutt
 * And more!
 
 ## Installation
+
+#### Homebrew (Recommended)
+
+```
+brew tap dugajean/goke
+brew install goke
+```
+
+#### GitHub releases
+
 Download the appropriate executable for your system from the [releases page](https://github.com/dugajean/goke/releases).
 
 ## Example configuration (goke.yml)


### PR DESCRIPTION
This PR sets up 

- Go Releaser as part of CI (Github Actions)
- Homebrew tap creation step