### PR TITLE
Add logic to bust parser cache & update tests

### DIFF
--- a/goke.yml
+++ b/goke.yml
@@ -13,7 +13,6 @@ genmocks:
     - "mockery --name=FileSystem --recursive --output=internal/tests --outpkg=tests --filename=filesystem_mock.go"
 
 greet-cats:
-  files: [cmd/cli/*]
   run:
     - 'echo "Hello Frey"'
-    - 'echo "Hello Sunny"'
+    - 'echo "Hello Bunny"'

--- a/internal/filesystem.go
+++ b/internal/filesystem.go
@@ -7,6 +7,7 @@ package internal
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 type FileSystem interface {
@@ -17,38 +18,43 @@ type FileSystem interface {
 	FileExists(filename string) bool
 	Remove(name string) error
 	TempDir() string
+	Glob(path string) ([]string, error)
 }
 
 type LocalFileSystem struct{}
 
-func (std *LocalFileSystem) ReadFile(name string) ([]byte, error) {
+func (fs *LocalFileSystem) ReadFile(name string) ([]byte, error) {
 	return os.ReadFile(name)
 }
 
-func (std *LocalFileSystem) WriteFile(name string, data []byte, perm fs.FileMode) error {
+func (fs *LocalFileSystem) WriteFile(name string, data []byte, perm fs.FileMode) error {
 	return os.WriteFile(name, data, perm)
 }
 
-func (std *LocalFileSystem) Getwd() (dir string, err error) {
+func (fs *LocalFileSystem) Getwd() (dir string, err error) {
 	return os.Getwd()
 }
 
-func (std *LocalFileSystem) Stat(name string) (fs.FileInfo, error) {
+func (fs *LocalFileSystem) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name)
 }
 
-func (std *LocalFileSystem) Remove(name string) error {
+func (fs *LocalFileSystem) Remove(name string) error {
 	return os.Remove(name)
 }
 
-func (std *LocalFileSystem) TempDir() string {
+func (fs *LocalFileSystem) TempDir() string {
 	return os.TempDir()
 }
 
-func (std *LocalFileSystem) FileExists(filename string) bool {
+func (fs *LocalFileSystem) FileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
 		return false
 	}
 	return !info.IsDir()
+}
+
+func (fs *LocalFileSystem) Glob(path string) ([]string, error) {
+	return filepath.Glob(path)
 }

--- a/internal/tests/filesystem_mock.go
+++ b/internal/tests/filesystem_mock.go
@@ -48,6 +48,29 @@ func (_m *FileSystem) Getwd() (string, error) {
 	return r0, r1
 }
 
+// Glob provides a mock function with given fields: path
+func (_m *FileSystem) Glob(path string) ([]string, error) {
+	ret := _m.Called(path)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ReadFile provides a mock function with given fields: name
 func (_m *FileSystem) ReadFile(name string) ([]byte, error) {
 	ret := _m.Called(name)

--- a/internal/tests/helpers.go
+++ b/internal/tests/helpers.go
@@ -24,7 +24,9 @@ func GetFileSystemMock(t *testing.T) any {
 	return fsMock
 }
 
-type MemFileInfo struct{}
+type MemFileInfo struct {
+	Mtime time.Time
+}
 
 func (fi MemFileInfo) Name() string {
 	return "foo"
@@ -39,6 +41,10 @@ func (fi MemFileInfo) Mode() fs.FileMode {
 }
 
 func (fi MemFileInfo) ModTime() time.Time {
+	if !fi.Mtime.IsZero() {
+		return fi.Mtime
+	}
+
 	return time.Date(2022, time.December, 24, 1, 1, 1, 1, time.UTC)
 }
 

--- a/internal/util.go
+++ b/internal/util.go
@@ -14,6 +14,16 @@ func GokeFiles() []string {
 	return []string{"goke.yml", "goke.yaml"}
 }
 
+func CurrentConfigFile() string {
+	for _, f := range GokeFiles() {
+		if FileExists(f) {
+			return f
+		}
+	}
+
+	return ""
+}
+
 func ReadYamlConfig() (string, error) {
 	for _, f := range GokeFiles() {
 		content, err := os.ReadFile(f)


### PR DESCRIPTION
Determine whether the cached tempfile is older then the modified time of the current config. If it is, then bust the cache.

Fixes #21 