### PR TITLE
Parser interface, dependencies udpated

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -24,7 +24,7 @@ func main() {
 	p := app.NewParser(cfg, &opts, &fs)
 	p.Bootstrap()
 
-	l := app.NewLockfile(p.FilePaths, &opts, &fs)
+	l := app.NewLockfile(p.GetFilePaths(), &opts, &fs)
 	l.Bootstrap()
 
 	e := app.NewExecutor(&p, &l, &opts)

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -126,9 +126,12 @@ func TestTaskParsing(t *testing.T) {
 
 	parser.parseTasks()
 
-	require.NotNil(t, parser.Tasks["greet-loki"])
-	require.NotNil(t, parser.Tasks["greet-cats"])
-	require.NotNil(t, parser.Tasks["greet-lisha"])
+	greetLoki, _ := parser.GetTask("greet-loki")
+	greetCats, _ := parser.GetTask("greet-cats")
+	greetLisha, _ := parser.GetTask("greet-lisha")
+	require.NotNil(t, greetLoki)
+	require.NotNil(t, greetCats)
+	require.NotNil(t, greetLisha)
 }
 
 func TestGlobalsParsing(t *testing.T) {
@@ -141,9 +144,10 @@ func TestGlobalsParsing(t *testing.T) {
 	require.True(t, strings.Contains(os.Getenv("BAR"), "bar"))
 	require.Equal(t, "baz", os.Getenv("BAZ"))
 
-	require.Equal(t, "foo", parser.Global.Shared.Environment["FOO"])
-	require.True(t, strings.Contains(parser.Global.Shared.Environment["BAR"], "bar"))
-	require.Equal(t, "baz", parser.Global.Shared.Environment["BAZ"])
+	global := parser.GetGlobal()
+	require.Equal(t, "foo", global.Shared.Environment["FOO"])
+	require.True(t, strings.Contains(global.Shared.Environment["BAR"], "bar"))
+	require.Equal(t, "baz", global.Shared.Environment["BAZ"])
 }
 
 func TestTaskGlobFilesExpansion(t *testing.T) {
@@ -154,7 +158,7 @@ func TestTaskGlobFilesExpansion(t *testing.T) {
 	parser := NewParser(yamlConfigStub, &clearCacheOpts, fsMock)
 
 	parser.parseTasks()
-	greetCatsTask := parser.Tasks["greet-cats"]
+	greetCatsTask, _ := parser.GetTask("greet-cats")
 
 	require.Equal(t, expectedGlob, greetCatsTask.Files)
 }


### PR DESCRIPTION
@dugajean Can you review the changes I made. I can see that you have made _Tasks_ and _FilePath_ public since we moved to interface we can make it private. Also we can create mocks of _Parser_ interface so you can test _Executor_ as well.

Also what is you opinion on moving methods that are not directly dependent on parser struct to individual function (like _parseSysteCmd_) we can move it to _util.go_

Once you review this I can start working on mocks and tests.
