### PR TITLE
Add support for --args to pass args to task cmds

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -9,10 +9,8 @@ import (
 )
 
 func main() {
-	argIndex := app.PermutateArgs(os.Args)
-	opts := app.GetOptions()
-
-	handleGlobalFlags(&opts)
+	opts := app.NewCliOptions()
+	handleGlobalOptions(&opts)
 
 	cfg, err := app.ReadYamlConfig()
 	if err != nil {
@@ -33,5 +31,5 @@ func main() {
 
 	ctx := context.Background()
 	e := app.NewExecutor(&p, &l, &opts, &proc, &fs, &ctx)
-	e.Start(parseTaskName(argIndex))
+	e.Start(opts.TaskName)
 }

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -7,32 +7,11 @@ import (
 	app "github.com/dugajean/goke/internal"
 )
 
-func parseTaskName(argIndex int) string {
-	arg := ""
-
-	if len(os.Args) > argIndex {
-		arg = os.Args[argIndex]
-	}
-
-	return arg
-}
-
-func handleGlobalFlags(opts *app.Options) {
-	// Handle global flags here
+// handleGlobalOptions executes the global options logic.
+func handleGlobalOptions(opts *app.Options) {
 	err := opts.InitHandler()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-	}
-
-	version, err := opts.VersionHandler()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if version != "" {
-		fmt.Println(version)
-		os.Exit(0)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dugajean/goke
 go 1.19
 
 require (
+	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/stretchr/testify v1.8.0
 	github.com/theckman/yacspin v0.13.12
 	gopkg.in/yaml.v3 v3.0.1
@@ -11,11 +12,12 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
-	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -27,8 +30,9 @@ github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/goke.yml
+++ b/goke.yml
@@ -14,7 +14,6 @@ genmocks:
     - "mockery --name=Process --recursive --output=internal/tests --outpkg=tests --filename=process_mock.go"
 
 greet-cats:
-  files: ["foo"]
   run:
     - 'echo "Hello Frey"'
     - 'echo "Hello Bunny"'

--- a/goke.yml
+++ b/goke.yml
@@ -1,5 +1,5 @@
 global:
-  environment:
+  env:
     BINARY: "goke"
 
 main: 

--- a/internal/executor_test.go
+++ b/internal/executor_test.go
@@ -46,8 +46,8 @@ func TestStartNonWatch(t *testing.T) {
 
 func TestStartWatchWithNoFiles(t *testing.T) {
 	watchOpts := Options{
-		Watch:      true,
-		ClearCache: true,
+		Watch:   true,
+		NoCache: true,
 	}
 
 	parser, lockfile, process, fsMock := getDependencies(t, &watchOpts)

--- a/internal/lockfile_test.go
+++ b/internal/lockfile_test.go
@@ -11,7 +11,7 @@ import (
 var files = []string{"./lockfile.go"}
 
 var lockfileOpts = Options{
-	ClearCache: true,
+	NoCache: true,
 }
 
 var dotGokeFile = `{

--- a/internal/options.go
+++ b/internal/options.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"log"
+
 	"github.com/docopt/docopt-go"
 )
 
@@ -9,7 +11,7 @@ const CURRENT_VERSION = "0.2.0"
 const usage = `Goke
 
 Usage:
-  goke <task> [-w|--watch] [-c|--no-cache] [-f|--force] [-q|--quiet] [-a|--args=<a>]
+  goke <task> [-w|--watch] [-c|--no-cache] [-f|--force] [-q|--quiet] [--] <args>...
   goke -i | --init
   goke -h | --help
   goke -v | --version
@@ -21,7 +23,6 @@ Options:
   -w --watch     Run task in watch mode
   -c --no-cache  Clears the program's cache
   -f --force     Runs the task even if files have not been changed
-  -a --args=<a>  The arguments to pass to the underlying commands
   -q --quiet     Suppresses all output from tasks`
 
 type Options struct {
@@ -30,7 +31,7 @@ type Options struct {
 	NoCache  bool     `docopt:"-c,--no-cache"`
 	Force    bool     `docopt:"-f,--force"`
 	Quiet    bool     `docopt:"-q,--quiet"`
-	Args     []string `docopt:"-a,--args"`
+	Args     []string `docopt:"<args>"`
 	Init     bool     `docopt:"-i,--init"`
 }
 
@@ -39,6 +40,8 @@ func NewCliOptions() Options {
 
 	parsedDoc, _ := docopt.ParseArgs(usage, nil, CURRENT_VERSION)
 	parsedDoc.Bind(&opts)
+
+	log.Fatal(opts.Args)
 
 	return opts
 }

--- a/internal/options.go
+++ b/internal/options.go
@@ -1,34 +1,44 @@
 package internal
 
 import (
-	"encoding/json"
-	"errors"
-	"flag"
-	"net/http"
-	"strings"
+	"github.com/docopt/docopt-go"
 )
 
-const GITHUB_TAGS_ENDPOINT = "https://api.github.com/repos/dugajean/goke/git/refs/tags"
+const CURRENT_VERSION = "0.2.0"
+
+const usage = `Goke
+
+Usage:
+  goke <task> [-w|--watch] [-c|--no-cache] [-f|--force] [-q|--quiet] [-a|--args=<a>]
+  goke -i | --init
+  goke -h | --help
+  goke -v | --version
+
+Options:
+  -h --help      Show this screen
+  -v --version   Show version
+  -i --init      Creates a goke.yaml file in the current directory
+  -w --watch     Run task in watch mode
+  -c --no-cache  Clears the program's cache
+  -f --force     Runs the task even if files have not been changed
+  -a --args=<a>  The arguments to pass to the underlying commands
+  -q --quiet     Suppresses all output from tasks`
 
 type Options struct {
-	ClearCache bool
-	Watch      bool
-	Force      bool
-	Init       bool
-	Quiet      bool
-	Version    bool
+	TaskName string   `docopt:"<task>"`
+	Watch    bool     `docopt:"-w,--watch"`
+	NoCache  bool     `docopt:"-c,--no-cache"`
+	Force    bool     `docopt:"-f,--force"`
+	Quiet    bool     `docopt:"-q,--quiet"`
+	Args     []string `docopt:"-a,--args"`
+	Init     bool     `docopt:"-i,--init"`
 }
 
-func GetOptions() Options {
+func NewCliOptions() Options {
 	var opts Options
 
-	flag.BoolVar(&opts.ClearCache, "no-cache", false, "Clear Goke's cache. Default: false")
-	flag.BoolVar(&opts.Watch, "watch", false, "Goke remains on and watches the task's specified files for changes, then reruns the command. Default: false")
-	flag.BoolVar(&opts.Force, "force", false, "Executes the task regardless whether the files have changed or not. Default: false")
-	flag.BoolVar(&opts.Init, "init", false, "Initializes a goke.yml file in the current directory")
-	flag.BoolVar(&opts.Quiet, "quiet", false, "Disables all output to the console. Default: false")
-	flag.BoolVar(&opts.Version, "version", false, "Prints the current Goke version")
-	flag.Parse()
+	parsedDoc, _ := docopt.ParseArgs(usage, nil, CURRENT_VERSION)
+	parsedDoc.Bind(&opts)
 
 	return opts
 }
@@ -44,35 +54,4 @@ func (opts *Options) InitHandler() error {
 	}
 
 	return nil
-}
-
-func (opts *Options) VersionHandler() (string, error) {
-	if !opts.Version {
-		return "", nil
-	}
-
-	res, err := http.Get(GITHUB_TAGS_ENDPOINT)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-
-	var refs []struct {
-		Ref string `json:"ref,omitempty"`
-	}
-
-	err = json.NewDecoder(res.Body).Decode(&refs)
-	if err != nil {
-		return "", err
-	}
-
-	if len(refs) == 0 {
-		return "", errors.New("could not retrieve version")
-	}
-
-	lastRef := refs[len(refs)-1].Ref
-	lastRefSplit := strings.Split(lastRef, "/")
-	lastRef = lastRefSplit[len(lastRefSplit)-1]
-
-	return lastRef, nil
 }

--- a/internal/options.go
+++ b/internal/options.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"log"
-
 	"github.com/docopt/docopt-go"
 )
 
@@ -11,7 +9,7 @@ const CURRENT_VERSION = "0.2.0"
 const usage = `Goke
 
 Usage:
-  goke <task> [-w|--watch] [-c|--no-cache] [-f|--force] [-q|--quiet] [--] <args>...
+  goke <task> [-w|--watch] [-c|--no-cache] [-f|--force] [-q|--quiet] [-a|--args=<a>...]
   goke -i | --init
   goke -h | --help
   goke -v | --version
@@ -23,6 +21,7 @@ Options:
   -w --watch     Run task in watch mode
   -c --no-cache  Clears the program's cache
   -f --force     Runs the task even if files have not been changed
+  -a --args=<a>  The arguments and options to pass to the underlying commands
   -q --quiet     Suppresses all output from tasks`
 
 type Options struct {
@@ -31,7 +30,7 @@ type Options struct {
 	NoCache  bool     `docopt:"-c,--no-cache"`
 	Force    bool     `docopt:"-f,--force"`
 	Quiet    bool     `docopt:"-q,--quiet"`
-	Args     []string `docopt:"<args>"`
+	Args     []string `docopt:"-a,--args"`
 	Init     bool     `docopt:"-i,--init"`
 }
 
@@ -40,8 +39,6 @@ func NewCliOptions() Options {
 
 	parsedDoc, _ := docopt.ParseArgs(usage, nil, CURRENT_VERSION)
 	parsedDoc.Bind(&opts)
-
-	log.Fatal(opts.Args)
 
 	return opts
 }

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -32,8 +32,8 @@ type Task struct {
 
 type Global struct {
 	Shared struct {
-		Environment map[string]string `yaml:"environment,omitempty"`
-		Events      struct {
+		Env    map[string]string `yaml:"environment,omitempty"`
+		Events struct {
 			BeforeEachRun  []string `yaml:"before_each_run,omitempty"`
 			AfterEachRun   []string `yaml:"after_each_run,omitempty"`
 			BeforeEachTask []string `yaml:"before_each_task,omitempty"`
@@ -183,12 +183,12 @@ func (p *parser) parseGlobal() error {
 		return err
 	}
 
-	vars, err := cli.SetEnvVariables(g.Shared.Environment)
+	vars, err := cli.SetEnvVariables(g.Shared.Env)
 	if err != nil {
 		return nil
 	}
 
-	g.Shared.Environment = vars
+	g.Shared.Env = vars
 	p.Global = g
 
 	return nil

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -225,7 +225,7 @@ func (p *parser) shouldClearCache(tempFile string) bool {
 	tempFileExists := p.fs.FileExists(tempFile)
 	mustCleanCache := false
 
-	if !p.options.ClearCache && tempFileExists {
+	if !p.options.NoCache && tempFileExists {
 		tempStat, _ := p.fs.Stat(tempFile)
 		tempModTime := tempStat.ModTime().Unix()
 
@@ -235,7 +235,7 @@ func (p *parser) shouldClearCache(tempFile string) bool {
 		mustCleanCache = tempModTime < configModTime
 	}
 
-	if p.options.ClearCache && tempFileExists {
+	if p.options.NoCache && tempFileExists {
 		mustCleanCache = true
 	}
 

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var clearCacheOpts = Options{
-	ClearCache: true,
+	NoCache: true,
 }
 
 var baseOptions = Options{}

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -105,9 +105,9 @@ func TestGlobalsParsing(t *testing.T) {
 	require.Equal(t, "baz", os.Getenv("BAZ"))
 
 	global := parser.GetGlobal()
-	require.Equal(t, "foo", global.Shared.Environment["FOO"])
-	require.True(t, strings.Contains(global.Shared.Environment["BAR"], "bar"))
-	require.Equal(t, "baz", global.Shared.Environment["BAZ"])
+	require.Equal(t, "foo", global.Shared.Env["FOO"])
+	require.True(t, strings.Contains(global.Shared.Env["BAR"], "bar"))
+	require.Equal(t, "baz", global.Shared.Env["BAZ"])
 }
 
 func TestTaskGlobFilesExpansion(t *testing.T) {

--- a/internal/util.go
+++ b/internal/util.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 func GokeFiles() []string {
@@ -97,18 +98,6 @@ func GOBDeserialize[T any](structStr string, structShell *T) T {
 	return *structShell
 }
 
-func PermutateArgs(args []string) int {
-	args = args[1:]
-	optind := 0
-
-	for i := range args {
-		if args[i][0] == '-' {
-			tmp := args[i]
-			args[i] = args[optind]
-			args[optind] = tmp
-			optind++
-		}
-	}
-
-	return optind + 1
+func JoinInnerArgs(args []string) string {
+	return strings.Join(args, " ")
 }


### PR DESCRIPTION
Solves #23 

Also parses CLI input via `docopt` instead of `flags`.