### PR TITLE
Remove 'global' from parsed tasks

### DIFF
--- a/internal/options.go
+++ b/internal/options.go
@@ -15,7 +15,7 @@ Usage:
   goke -i | --init
   goke -h | --help
   goke -v | --version
-  goke -t | --tasks
+  goke -t | --tasks [-c|--no-cache]
 
 Options:
   -h --help      Show this screen

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -168,6 +168,8 @@ func (p *parser) parseTasks() error {
 		tasks[k] = c
 	}
 
+	delete(tasks, "global")
+
 	p.FilePaths = allFilesPaths
 	p.Tasks = tasks
 


### PR DESCRIPTION
Fixes #32 

Removes `global` from the parsed tasks list.